### PR TITLE
Remove trace_id from metadata when trace finishes

### DIFF
--- a/lib/tapper/tracer.ex
+++ b/lib/tapper/tracer.ex
@@ -208,6 +208,7 @@ defmodule Tapper.Tracer do
   def finish(id = %Tapper.Id{}, opts) when is_list(opts) do
     end_timestamp = Timestamp.instant()
 
+    Logger.metadata(trace_id: nil)
     GenServer.cast(via_tuple(id), {:finish, end_timestamp, opts})
   end
 

--- a/test/tracer_test.exs
+++ b/test/tracer_test.exs
@@ -27,6 +27,7 @@ defmodule TracerTest do
 
       Tracer.finish(id)
 
+      assert Logger.metadata() == []
       assert_receive {:DOWN, ^ref, _, _, _}, 1000
   end
 


### PR DESCRIPTION
Currently the trace_id remains in Logger.metadata even after the trace is finished. The trace_id is visible in the same process that started the trace.