### PR TITLE
only set shared flag true for joined traces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ erl_crash.dump
 
 # Also ignore archive artifacts (built via "mix archive.build").
 *.ez
+
+.elixir_ls

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+v0.3.5
+* DEFECT: shared span flag should only be true for joined traces, not all `:server` traces.
+
 v0.3.4
 * Add `Tapper.Reporter.Null` (HT @TKasekamp)
 * Doc fixes.

--- a/lib/tapper/tracer.ex
+++ b/lib/tapper/tracer.ex
@@ -64,7 +64,7 @@ defmodule Tapper.Tracer do
 
     # don't even start tracer if sampled is false
     if id.sampled do
-      trace_init = {trace_id, span_id, :root, sample, debug}
+      trace_init = {trace_id, span_id, :root, sample, debug, false}
 
       {:ok, _pid} = Tapper.Tracer.Supervisor.start_tracer(trace_init, timestamp, opts)
     end
@@ -113,7 +113,7 @@ defmodule Tapper.Tracer do
   * `type` determines the type of an automatically created `sr` (`:server`) or `cs` (`:client`) annotation, see also `Tapper.client_send/0` and `Tapper.server_receive/0`.
   """
   def join(trace_id, span_id, parent_id, sample, debug, opts \\ []), do: join({trace_id, span_id, parent_id, sample, debug}, opts)
-  def join(trace_init = {trace_id, span_id, parent_id, sample, debug}, opts \\ []) when is_list(opts) do
+  def join({trace_id, span_id, parent_id, sample, debug}, opts \\ []) when is_list(opts) do
 
     timestamp = Timestamp.instant()
 
@@ -121,6 +121,8 @@ defmodule Tapper.Tracer do
     {opts, _sample, _trace} = preflight_opts(opts, :server)
 
     id = Tapper.Id.init(trace_id, span_id, parent_id, sample, debug)
+
+    trace_init = {trace_id, span_id, parent_id, sample, debug, true}
 
     if id.sampled do
       {:ok, _pid} = Tapper.Tracer.Supervisor.start_tracer(trace_init, timestamp, opts)

--- a/lib/tapper/tracer/trace_to_protocol.ex
+++ b/lib/tapper/tracer/trace_to_protocol.ex
@@ -41,10 +41,14 @@ defmodule Tapper.Tracer.Trace.Convert do
     * calculated durations < 1 microsecond, which we round up to 1 microsecond
   """
   @spec span_duration(span :: Trace.SpanInfo.t, trace :: Trace.t) :: nil | pos_integer()
+  def span_duration(span, trace)
+
   def span_duration(%Trace.SpanInfo{shared: true}, _trace), do: nil
+
   def span_duration(%Trace.SpanInfo{start_timestamp: start_timestamp, end_timestamp: nil}, %Trace{end_timestamp: trace_end_timestamp}) do
     max(Timestamp.duration(start_timestamp, trace_end_timestamp), 1)
   end
+
   def span_duration(%Trace.SpanInfo{start_timestamp: start_timestamp, end_timestamp: end_timestamp}, _trace) do
     max(Timestamp.duration(start_timestamp, end_timestamp), 1)
   end

--- a/lib/tapper/tracer/tracer_api.ex
+++ b/lib/tapper/tracer/tracer_api.ex
@@ -38,7 +38,7 @@ defmodule Tapper.Tracer.Api do
   @typedoc "Denote a client span or a server span; used to automatically add `:sr` or `:cs` annotation."
   @type span_type :: :client | :server
 
-  @type trace_init :: {trace_id :: Tapper.TraceId.t, span_id :: Tapper.SpanId.t, parent_span_id :: Tapper.SpanId.t | :root, sample :: boolean, debug :: boolean}
+  @type trace_init :: {trace_id :: Tapper.TraceId.t, span_id :: Tapper.SpanId.t, parent_span_id :: Tapper.SpanId.t | :root, sample :: boolean, debug :: boolean, shared :: boolean}
 
   # operations
   @callback start(opts :: Keyword.t) :: Tapper.Id.t

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Tapper.Mixfile do
 
   def project do
     [app: :tapper,
-     version: "0.3.4",
+     version: "0.3.5",
      elixir: "~> 1.4",
      elixirc_paths: elixirc_paths(Mix.env),
      build_embedded: Mix.env == :prod,

--- a/mix.lock
+++ b/mix.lock
@@ -1,12 +1,13 @@
-%{"benchee": {:hex, :benchee, "0.9.0", "433d946b0e4755e186fe564568ead4f593b0d15337fcffa95ed7d5b8a6612670", [:mix], [{:deep_merge, "~> 0.1", [hex: :deep_merge, optional: false]}]},
+%{
+  "benchee": {:hex, :benchee, "0.9.0", "433d946b0e4755e186fe564568ead4f593b0d15337fcffa95ed7d5b8a6612670", [:mix], [{:deep_merge, "~> 0.1", [hex: :deep_merge, optional: false]}]},
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], []},
   "certifi": {:hex, :certifi, "2.0.0", "a0c0e475107135f76b8c1d5bc7efb33cd3815cb3cf3dea7aefdd174dabead064", [:rebar3], []},
-  "credo": {:hex, :credo, "0.8.8", "990e7844a8d06ebacd88744a55853a83b74270b8a8461c55a4d0334b8e1736c9", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}], "hexpm"},
+  "credo": {:hex, :credo, "0.8.10", "261862bb7363247762e1063713bb85df2bbd84af8d8610d1272cd9c1943bba63", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}], "hexpm"},
   "deep_merge": {:hex, :deep_merge, "0.1.1", "c27866a7524a337b6a039eeb8dd4f17d458fd40fbbcb8c54661b71a22fffe846", [:mix], []},
   "deferred_config": {:hex, :deferred_config, "0.1.1", "ec912e9ee3c99b90a8d4bdec8fbd15309f4bd6729f30789e0ff6f595d06bbce5", [:mix], []},
   "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], []},
-  "earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.17.1", "39f777415e769992e6732d9589dc5846ea587f01412241f4a774664c746affbb", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+  "earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.18.1", "37c69d2ef62f24928c1f4fdc7c724ea04aecfdf500c4329185f8e3649c915baf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "fs": {:hex, :fs, "0.9.2", "ed17036c26c3f70ac49781ed9220a50c36775c6ca2cf8182d123b6566e49ec59", [:rebar], []},
   "hackney": {:hex, :hackney, "1.9.0", "51c506afc0a365868469dcfc79a9d0b94d896ec741cfd5bd338f49a5ec515bfe", [:rebar3], [{:certifi, "2.0.0", [hex: :certifi, optional: false]}, {:idna, "5.1.0", [hex: :idna, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, optional: false]}]},
   "httpoison": {:hex, :httpoison, "0.13.0", "bfaf44d9f133a6599886720f3937a7699466d23bb0cd7a88b6ba011f53c6f562", [:mix], [{:hackney, "~> 1.8", [hex: :hackney, optional: false]}]},
@@ -17,4 +18,5 @@
   "mix_test_watch": {:hex, :mix_test_watch, "0.5.0", "2c322d119a4795c3431380fca2bca5afa4dc07324bd3c0b9f6b2efbdd99f5ed3", [:mix], [{:fs, "~> 0.9.1", [hex: :fs, repo: "hexpm", optional: false]}], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], []},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], []},
-  "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [:rebar3], []}}
+  "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [:rebar3], []},
+}

--- a/test/support/server_helper.ex
+++ b/test/support/server_helper.ex
@@ -32,8 +32,9 @@ defmodule Test.Helper.Server do
     trace_id = Tapper.TraceId.generate()
     span_id = Tapper.SpanId.generate()
     timestamp = Timestamp.instant()
+    shared = opts[:shared] || false
 
-    {:ok, trace, _ttl} = Tapper.Tracer.Server.init([config, {trace_id, span_id, :root, true, false}, self(), timestamp, opts])
+    {:ok, trace, _ttl} = Tapper.Tracer.Server.init([config, {trace_id, span_id, :root, true, false, shared}, self(), timestamp, opts])
     {trace, span_id}
   end
 

--- a/test/tapper_test.exs
+++ b/test/tapper_test.exs
@@ -44,6 +44,10 @@ defmodule TapperTest do
     child_1 = protocol_span_by_name(spans, "child-1")
     child_2 = protocol_span_by_name(spans, "child-2")
 
+    assert child_1.parent_id == main_span.id
+    assert child_2.parent_id == main_span.id
+
+    assert main_span.duration
     assert length(main_span.annotations) == 1
     assert protocol_annotation_by_value(main_span, :cs)
     assert protocol_binary_annotation_by_key(main_span, :sa)
@@ -93,6 +97,7 @@ defmodule TapperTest do
     assert main_span.id == span_id
     assert main_span.trace_id == elem(trace_id, 0)
     assert main_span.parent_id == parent_span_id
+    assert main_span.duration == nil
 
     assert protocol_binary_annotation_by_key(main_span, :ca)
     assert protocol_binary_annotation_by_key(main_span, :ca).host == Tapper.Tracer.Trace.Convert.to_protocol_endpoint(remote_endpoint)

--- a/test/tracer/server_init_test.exs
+++ b/test/tracer/server_init_test.exs
@@ -13,7 +13,7 @@ defmodule Tracer.Server.InitTest do
     span_id = Tapper.SpanId.generate()
     timestamp = Timestamp.instant()
 
-    {:ok, trace, ttl} = Tapper.Tracer.Server.init([config, {trace_id, span_id, :root, true, false}, self(), timestamp, []])
+    {:ok, trace, ttl} = Tapper.Tracer.Server.init([config, {trace_id, span_id, :root, true, false, false}, self(), timestamp, []])
 
     assert trace.trace_id == trace_id
     assert trace.span_id == span_id
@@ -60,17 +60,17 @@ defmodule Tracer.Server.InitTest do
     span_id = Tapper.SpanId.generate()
     timestamp = Timestamp.instant()
 
-    {:ok, trace, ^ttl} = Tapper.Tracer.Server.init([config, {trace_id, span_id, :root, true, false}, self(), timestamp, [ttl: ttl]])
+    {:ok, trace, ^ttl} = Tapper.Tracer.Server.init([config, {trace_id, span_id, :root, true, false, false}, self(), timestamp, [ttl: ttl]])
 
     assert trace.ttl == ttl
   end
 
-  test "init, type: server; is shared, adds :sr annotation" do
+  test "init, type: server; adds :sr annotation" do
     {trace, span_id} = init_with_opts(type: :server)
 
     span = trace.spans[span_id]
 
-    assert span.shared, "expected server span to be shared"
+    refute span.shared, "expected server span not to be shared by default"
 
     annotations = trace.spans[span_id].annotations
     assert length(annotations) == 1
@@ -132,11 +132,9 @@ defmodule Tracer.Server.InitTest do
 
   test "init, type: server, remote: endpoint adds client address binary annotation" do
     remote = random_endpoint()
-    {trace, span_id} = init_with_opts(type: :server, remote: remote)
+    {trace, span_id} = init_with_opts(type: :server, remote: remote, shared: true)
 
     span = trace.spans[span_id]
-
-    assert span.shared
 
     annotations = span.annotations
     assert length(annotations) == 1


### PR DESCRIPTION
* DEFECT: shared span flag should only be true for joined traces, not all `:server` traces.
