### PR TITLE
Add AsyncReporter for sending spans in batches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: elixir
 elixir:
-    - 1.4.2
+    - 1.6.6
+    - 1.7.3
 opt_release:
     - 19.3
 after_script:

--- a/README.md
+++ b/README.md
@@ -200,7 +200,11 @@ e.g. in `config.exs` (or `prod.exs` etc.)
 ```elixir
 config :tapper,
     system_id: "my-application",
-    reporter: Tapper.Reporter.Zipkin
+    reporter: Tapper.Reporter.AsyncReporter
+
+config :tapper, Tapper.Reporter.AsyncReporter,
+    flush_interval: 10000,
+    sender: Tapper.Reporter.Zipkin
 
 config :tapper, Tapper.Reporter.Zipkin,
     collector_url: "http://localhost:9411/api/v1/spans"

--- a/lib/tapper/application.ex
+++ b/lib/tapper/application.ex
@@ -72,11 +72,19 @@ defmodule Tapper.Application do
     }
 
     Logger.info("Starting Tapper Application")
+
     # Define workers and child supervisors to be supervised
     children = [
       supervisor(Registry, [:unique, Tapper.Tracers]),
       supervisor(Tapper.Tracer.Supervisor, [config]),
     ]
+
+    children =
+      if config[:reporter] == Tapper.Reporter.AsyncReporter do
+        [worker(Tapper.Reporter.AsyncReporter, [], restart: :transient) | children]
+      else
+        children
+      end
 
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html
     # for other strategies and supported options

--- a/lib/tapper/reporter/async_reporter.ex
+++ b/lib/tapper/reporter/async_reporter.ex
@@ -1,0 +1,157 @@
+defmodule Tapper.Reporter.AsyncReporter do
+  @moduledoc """
+  Reporter that collects spans and forwards them periodically.
+
+  ## Configuration
+
+  | key | purpose | default/required |
+  | `flush_interval` | Milliseconds to wait between reporting a new batch of spans | 10000 |
+  | `sender` | Sender to use when reporting a batch. (e.g. Tapper.Reporter.Zipkin) | Required |
+  | `max_concurrent_flush_count` | Number of flushes that can work concurrently before we start discarding new spans | 5 |
+  | `max_spans_threshold` | Reaching this number of spans will reset the flush_interval timer and will flush the spans | 1000 |
+
+  e.g.
+  ```
+  config :tapper,
+    system_id: "my-application",
+    reporter: Tapper.Reporter.AsyncReporter
+
+  config :tapper, Tapper.Reporter.AsyncReporter,
+    flush_interval: 10000,
+    max_spans_threshold: 1000,
+    max_concurrent_flush_count: 5,
+    sender: Tapper.Reporter.Zipkin
+
+  config :tapper, Tapper.Reporter.Zipkin,
+    collector_url: "https://my-zipkin.domain.com:9411/api/v1/spans",
+    client_opts: [timeout: 10000]
+  """
+
+  use GenServer
+
+  require Logger
+
+  @behaviour Tapper.Reporter.Api
+
+  # 10 seconds
+  @default_flush_interval 10000
+
+  @default_max_concurrent_flush_count 5
+
+  @default_max_spans_threshold 1000
+
+  @default_sender Tapper.Reporter.Console
+
+  # Client
+
+  def start_link(spans \\ [], opts \\ []) do
+    Logger.info("Starting Tapper.Reporter.AsyncReporter")
+
+    config = Application.get_env(:tapper, __MODULE__)
+    flush_interval = opts[:flush_interval] || config[:flush_interval] || @default_flush_interval
+    sender = opts[:sender] || config[:sender] || @default_sender
+
+    max_concurrent_flush_threshold =
+      opts[:max_concurrent_flush_threshold] || config[:max_concurrent_flush_threshold] ||
+        @default_max_concurrent_flush_count
+
+    max_spans_threshold =
+      opts[:max_spans_threshold] || config[:max_spans_threshold] || @default_max_spans_threshold
+
+    GenServer.start_link(
+      __MODULE__,
+      %{
+        flush_interval: flush_interval,
+        spans: spans,
+        sender: sender,
+        max_concurrent_flush_threshold: max_concurrent_flush_threshold,
+        max_spans_threshold: max_spans_threshold
+      },
+      name: __MODULE__
+    )
+  end
+
+  @impl true
+  def ingest(spans) when is_list(spans) do
+    GenServer.cast(__MODULE__, {:ingest, spans})
+  end
+
+  def flush do
+    GenServer.call(__MODULE__, :flush_now)
+  end
+
+  # Server
+
+  @impl true
+  def init(state) do
+    {:ok, flushing_counter} = Agent.start_link(fn -> 0 end, name: :async_reporter_flushing_count)
+
+    {:ok, Map.merge(%{flushing_counter: flushing_counter}, schedule_flush(state))}
+  end
+
+  @impl true
+  def handle_cast(
+        {:ingest, new_spans},
+        %{spans: spans, max_spans_threshold: max_spans_threshold} = state
+      ) do
+    state = %{state | spans: spans ++ new_spans}
+
+    if length(state[:spans]) >= max_spans_threshold do
+      {:noreply, flush!(state)}
+    else
+      {:noreply, state}
+    end
+  end
+
+  @impl true
+  def handle_call(:flush_now, _from, state) do
+    {:reply, :ok, flush!(state)}
+  end
+
+  @impl true
+  def handle_info(:flush, state) do
+    {:noreply, flush!(state)}
+  end
+
+  defp flush!(%{spans: spans, sender: sender} = state) when length(spans) > 0 do
+    with :ok <- prepare_for_flush(state) do
+      Task.start(fn ->
+        try do
+          sender.ingest(spans)
+        after
+          finish_flush(state)
+        end
+      end)
+    end
+
+    %{schedule_flush(state) | spans: []}
+  end
+
+  defp flush!(state), do: state
+
+  defp schedule_flush(%{flush_interval: flush_interval} = state) do
+    if state[:timer] do
+      Process.cancel_timer(state[:timer])
+    end
+
+    timer = Process.send_after(self(), :flush, flush_interval)
+    Map.merge(state, %{timer: timer})
+  end
+
+  defp prepare_for_flush(%{
+         flushing_counter: flushing_counter,
+         max_concurrent_flush_threshold: max_concurrent_flush_threshold
+       }) do
+    Agent.get_and_update(flushing_counter, fn count ->
+      if count < max_concurrent_flush_threshold do
+        {:ok, count + 1}
+      else
+        {:error, count}
+      end
+    end)
+  end
+
+  defp finish_flush(%{flushing_counter: flushing_counter}) do
+    Agent.update(flushing_counter, fn count -> count - 1 end)
+  end
+end

--- a/lib/tapper/reporter/zipkin.ex
+++ b/lib/tapper/reporter/zipkin.ex
@@ -3,7 +3,7 @@ defmodule Tapper.Reporter.Zipkin do
   Reporter that sends spans to Zipkin Server API.
 
   * Currently supports only JSON encoding.
-  * Does not batch spans: would probably be done with an intermediate.
+  * Use AsyncReporter with this module as a sender to send spans in batches
 
   ## See also
 

--- a/mix.exs
+++ b/mix.exs
@@ -67,7 +67,8 @@ defmodule Tapper.Mixfile do
       {:mix_test_watch, "~> 0.3", only: :dev, runtime: false},
       {:ex_doc, "~> 0.14", only: :dev, runtime: false},
       {:dialyxir, "~> 0.5", only: [:dev]},
-      {:inch_ex, ">= 0.0.0", only: :docs}
+      {:inch_ex, ">= 0.0.0", only: :docs},
+      {:mox, "~> 0.4", only: :test}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -16,6 +16,7 @@
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], []},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
   "mix_test_watch": {:hex, :mix_test_watch, "0.5.0", "2c322d119a4795c3431380fca2bca5afa4dc07324bd3c0b9f6b2efbdd99f5ed3", [:mix], [{:fs, "~> 0.9.1", [hex: :fs, repo: "hexpm", optional: false]}], "hexpm"},
+  "mox": {:hex, :mox, "0.4.0", "7f120840f7d626184a3d65de36189ca6f37d432e5d63acd80045198e4c5f7e6e", [], [], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], []},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], []},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [:rebar3], []},

--- a/test/reporter/async_reporter_test.exs
+++ b/test/reporter/async_reporter_test.exs
@@ -1,0 +1,88 @@
+defmodule Tapper.Reporter.AsyncReporterTest do
+  use ExUnit.Case, async: false
+
+  import Mox
+
+  alias Tapper.Reporter.AsyncReporter
+
+  setup :set_mox_global
+
+  # Make sure mocks are verified when the test exits
+  setup :verify_on_exit!
+
+  test "concats spans until flush is called" do
+    first_span = "first-span"
+    second_span = "second-span"
+
+    MockSender
+    |> expect(:ingest, fn [^first_span, ^second_span] -> :ok end)
+
+    AsyncReporter.start_link([], sender: MockSender)
+    AsyncReporter.ingest([first_span])
+    AsyncReporter.ingest([second_span])
+    AsyncReporter.flush()
+
+    # Let the worker finish
+    Process.sleep(10)
+  end
+
+  test "reports spans periodically" do
+    first_span = "first-span"
+    second_span = "second-span"
+
+    MockSender
+    |> expect(:ingest, fn [^first_span] -> :ok end)
+    |> expect(:ingest, fn [^second_span] -> :ok end)
+
+    AsyncReporter.start_link([], sender: MockSender, flush_interval: 5)
+
+    AsyncReporter.ingest([first_span])
+    Process.sleep(10)
+
+    AsyncReporter.ingest([second_span])
+    Process.sleep(10)
+  end
+
+  test "reports spans when max_spans_threshold is hit" do
+    first_span = "first-span"
+    second_span = "second-span"
+
+    MockSender
+    |> expect(:ingest, fn [^first_span] -> :ok end)
+    |> expect(:ingest, fn [^second_span] -> :ok end)
+
+    AsyncReporter.start_link([], sender: MockSender, max_spans_threshold: 1)
+    AsyncReporter.ingest([first_span])
+    AsyncReporter.ingest([second_span])
+    AsyncReporter.flush()
+
+    # Let the worker finish
+    Process.sleep(10)
+  end
+
+  test "does not spawn more than max_concurrent_flush_threshold workers" do
+    first_span = "first-span"
+    second_span = "second-span"
+    third_span = "third-span"
+
+    # Third span is ignored because the first two exhausted the max concurrent
+    # flush threshold
+    MockSender
+    |> expect(:ingest, fn [^first_span] -> Process.sleep(10) end)
+    |> expect(:ingest, fn [^second_span] -> Process.sleep(10) end)
+
+    AsyncReporter.start_link([], sender: MockSender, max_concurrent_flush_threshold: 2)
+
+    AsyncReporter.ingest([first_span])
+    AsyncReporter.flush()
+
+    AsyncReporter.ingest([second_span])
+    AsyncReporter.flush()
+
+    AsyncReporter.ingest([third_span])
+    AsyncReporter.flush()
+
+    # Let the workers finish
+    Process.sleep(20)
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,3 @@
 ExUnit.start()
+
+Mox.defmock(MockSender, for: Tapper.Reporter.Api)


### PR DESCRIPTION
Sending every sampled trace separately can create a lot of traffic between the application and zipkin server when the server is handling a lot of client traffic. Instead collect the spans and send them in batches.

This is a backwards compatible change. I'd like to change Zipkin reporter to URL Sender or something similar to the official zipkin libraries (e.g. brave) but decided not to break backwards compatibility here.