### PR TITLE
Fix deprecation warnings from System.convert_time_unit/3

### DIFF
--- a/lib/tapper/timestamp.ex
+++ b/lib/tapper/timestamp.ex
@@ -17,14 +17,14 @@ defmodule Tapper.Timestamp do
   @spec to_absolute(t :: t) :: microseconds_timestamp()
   def to_absolute(timestamp)
   def to_absolute({timestamp, offset}) do
-    System.convert_time_unit(timestamp + offset, :native, :microseconds)
+    System.convert_time_unit(timestamp + offset, :native, :microsecond)
   end
 
   @doc "Calculate the different between two timestamp, in microseconds."
   @spec duration(t1 :: t, t2 :: t) :: microseconds_timestamp()
   def duration(t1, t2)
   def duration({timestamp1, _}, {timestamp2, _}) do
-    System.convert_time_unit(timestamp2 - timestamp1, :native, :microseconds)
+    System.convert_time_unit(timestamp2 - timestamp1, :native, :microsecond)
   end
 
   @doc false

--- a/test/timestamp_test.exs
+++ b/test/timestamp_test.exs
@@ -14,20 +14,20 @@ defmodule TimestampTest do
   test "to_absolute/1 adjusts instant to offset and microseconds" do
     ts = {timestamp, offset} = Timestamp.instant()
 
-    assert Timestamp.to_absolute(ts) == System.convert_time_unit(timestamp + offset, :native, :microseconds)
+    assert Timestamp.to_absolute(ts) == System.convert_time_unit(timestamp + offset, :native, :microsecond)
   end
 
   test "duration/2 calculates difference in microseconds" do
     t1 = {timestamp, _offset} = Timestamp.instant()
     t2 = {timestamp + 5_000, 100_000_000}
 
-    assert Timestamp.duration(t1, t2) === System.convert_time_unit(5_000, :native, :microseconds)
+    assert Timestamp.duration(t1, t2) === System.convert_time_unit(5_000, :native, :microsecond)
   end
 
   test "incr/3 adds in native units" do
     t = {timestamp, offset} = Timestamp.instant()
-    assert Timestamp.incr(t, 50, :milliseconds) == {
-      timestamp + System.convert_time_unit(50, :milliseconds, :native), offset
+    assert Timestamp.incr(t, 50, :millisecond) == {
+      timestamp + System.convert_time_unit(50, :millisecond, :native), offset
     }
   end
 

--- a/test/tracer/server_span_test.exs
+++ b/test/tracer/server_span_test.exs
@@ -35,7 +35,7 @@ defmodule Tracer.Server.SpanTest do
 
     {:noreply, state, _ttl} = Tapper.Tracer.Server.handle_cast({:start_span, child_span, []}, trace)
 
-    child_end_timestamp = Timestamp.incr(timestamp, 100, :milliseconds)
+    child_end_timestamp = Timestamp.incr(timestamp, 100, :millisecond)
     {:noreply, state, _ttl} = Tapper.Tracer.Server.handle_cast({:finish_span, child_span.id, child_end_timestamp, annotations: [Tapper.Tracer.annotation_delta(:xx)]}, state)
 
     assert state.spans[child_span.id]


### PR DESCRIPTION
Plural from_unit and to_unit are deprecated in newer elixir versions.

This caused:
```
  warning: deprecated time unit: :milliseconds. A time unit should be :second, :millisecond, :microsecond, :nanosecond, or a positive integer
```

Can you also please release a new version with this?