### PR TITLE
Allow annotations to be strings so it may work with Zipkin V2

### DIFF
--- a/lib/tapper/tracer.ex
+++ b/lib/tapper/tracer.ex
@@ -388,7 +388,7 @@ defmodule Tapper.Tracer do
   | :wire_send | `ws` |
   | :wire_recv | `wr` |
   """
-  def map_annotation_type(type) when is_atom(type) do
+  def map_annotation_type(type) when is_atom(type) or is_binary(type) do
     case type do
       :client_send -> :cs
       :client_recv -> :cr

--- a/lib/tapper/tracer/annotations.ex
+++ b/lib/tapper/tracer/annotations.ex
@@ -10,7 +10,7 @@ defmodule Tapper.Tracer.Annotations do
 
   @spec annotation(value :: atom() | String.t, timestamp :: Timestamp.t, Tapper.Endpoint.t) :: Trace.Annotation.t
   def annotation(value, timestamp, endpoint)
-  def annotation(value, timestamp, endpoint = %Tapper.Endpoint{}) when is_atom(value) and is_tuple(timestamp) do
+  def annotation(value, timestamp, endpoint = %Tapper.Endpoint{}) when (is_atom(value) or is_binary(value)) and is_tuple(timestamp) do
     Trace.Annotation.new(value, timestamp, endpoint)
   end
 

--- a/lib/tapper/tracer/server.ex
+++ b/lib/tapper/tracer/server.ex
@@ -244,7 +244,7 @@ defmodule Tapper.Tracer.Server do
     %{trace | async: true}
   end
 
-  def apply_update(value, trace = %Trace{}, span_id, timestamp, default_endpoint) when is_atom(value) do
+  def apply_update(value, trace = %Trace{}, span_id, timestamp, default_endpoint) when is_atom(value) or is_binary(value) do
     annotation = Annotations.annotation(value, timestamp, default_endpoint)
     update_span(trace, span_id, fn(span) -> %{span | annotations: [annotation | span.annotations]} end)
   end

--- a/test/support/server_helper.ex
+++ b/test/support/server_helper.ex
@@ -99,7 +99,7 @@ defmodule Test.Helper.Server do
     {:update, span_id, timestamp, [Tracer.annotation_delta(value, endpoint)]}
   end
 
-  def annotation_update_message(span_id, timestamp, value) when is_atom(value) do
+  def annotation_update_message(span_id, timestamp, value) do
     {:update, span_id, timestamp, [value]}
   end
 

--- a/test/tracer/server_annotation_test.exs
+++ b/test/tracer/server_annotation_test.exs
@@ -52,6 +52,24 @@ defmodule Tracer.Server.AnnotationTest do
     } == hd(span.annotations)
   end
 
+  test "add string annotatation" do
+    {trace, span_id} = init_with_opts()
+
+    timestamp = Timestamp.instant()
+    value = "some annotation"
+
+    {:noreply, state, _ttl} =
+        Tapper.Tracer.Server.handle_cast(annotation_update_message(span_id, timestamp, "some annotation"), trace)
+
+    span = state.spans[span_id]
+
+    assert %Trace.Annotation{
+      value: value,
+      timestamp: timestamp,
+      host: Trace.endpoint_from_config(config())
+    } == hd(span.annotations)
+  end
+
   test "handles a single annotatation rather than a list of annotations" do
     {trace, span_id} = init_with_opts()
 

--- a/test/tracer/server_init_test.exs
+++ b/test/tracer/server_init_test.exs
@@ -183,6 +183,16 @@ defmodule Tracer.Server.InitTest do
     assert binary_annotation_by_key(trace.spans[span_id], "temp")
   end
 
+  test "init with string annotations adds annotations" do
+    {trace, span_id} = init_with_opts(name: "name", annotations: [
+      Tracer.annotation_delta("something"),
+      Tracer.binary_annotation_delta(:double, "temp", 69.2)
+    ])
+
+    assert annotation_by_value(trace.spans[span_id], "something")
+    assert binary_annotation_by_key(trace.spans[span_id], "temp")
+  end
+
   test "init with non-list annotations: adds annotation" do
     {trace, span_id} = init_with_opts(name: "name", annotations: Tracer.annotation_delta(:ws))
 

--- a/test/tracer/server_span_test.exs
+++ b/test/tracer/server_span_test.exs
@@ -36,13 +36,19 @@ defmodule Tracer.Server.SpanTest do
     {:noreply, state, _ttl} = Tapper.Tracer.Server.handle_cast({:start_span, child_span, []}, trace)
 
     child_end_timestamp = Timestamp.incr(timestamp, 100, :millisecond)
-    {:noreply, state, _ttl} = Tapper.Tracer.Server.handle_cast({:finish_span, child_span.id, child_end_timestamp, annotations: [Tapper.Tracer.annotation_delta(:xx)]}, state)
+    {:noreply, state, _ttl} =
+      Tapper.Tracer.Server.handle_cast({:finish_span, child_span.id, child_end_timestamp,
+        annotations: [
+          Tapper.Tracer.annotation_delta(:xx),
+          Tapper.Tracer.annotation_delta("something")
+        ]}, state)
 
     assert state.spans[child_span.id]
     assert state.spans[child_span.id].start_timestamp == timestamp
     assert state.spans[child_span.id].end_timestamp == child_end_timestamp
     assert state.last_activity == child_end_timestamp
     assert annotation_by_value(state.spans[child_span.id], :xx)
+    assert annotation_by_value(state.spans[child_span.id], "something")
   end
 
   test "start_span with local context option adds lc annotation" do


### PR DESCRIPTION
The typespecs imply that annotations can be strings, however the code prevents that from working. This PR changes that allowing for string annotations. 

I'd also like to create a Zipkin V2 exporter and it would be very helpful to allow strings here to make it match the API better.